### PR TITLE
OrangeBox support for text-only lightboxes, no images being loaded/shipped with the plug-in

### DIFF
--- a/orangebox/css/orangebox.css
+++ b/orangebox/css/orangebox.css
@@ -74,6 +74,9 @@
 	line-height:1.625em;
 }
 #ob_load {
+	background:url(loading.gif) no-repeat center;
+}
+#ob_load,#ob_load_text {
 	-moz-border-radius:5px;
 	background:url(loading.gif) no-repeat center;
 	background-color:#fff;
@@ -95,6 +98,8 @@
 }
 #ob_close {
 	background:url(buttons.png);
+}
+#ob_close, #ob_close_text {
 	cursor:pointer;
 	height:30px;
 	left:-26px;
@@ -102,6 +107,9 @@
 	top:-26px;
 	width:30px;
 	z-index:1005;
+}
+#ob_close_text {
+	top:-16px;
 }
 #ob_title {
 	color:#fff;
@@ -168,3 +176,22 @@
 }
 #ob_dots .current { background-color:#CCC!important; }
 #ob_share { margin-left:8px; }
+#ob_close_text,.ob_controls,#ob_load_text {
+	color: #fff;
+	font-size: 250%;
+	text-shadow: 1px 1px 1px #000;
+	filter: dropshadow(color=#000, offx=1, offy=1);
+}
+.ob_controls {
+	cursor:pointer;
+	display:block;
+	height:30px;
+	margin-top:-9px;
+	position:absolute;
+	top:50%;
+	width:100%;
+	z-index:1004;
+}
+#ob_left, .ob_left {
+	text-align: right;
+}

--- a/orangebox/css/orangebox.css
+++ b/orangebox/css/orangebox.css
@@ -176,7 +176,7 @@
 }
 #ob_dots .current { background-color:#CCC!important; }
 #ob_share { margin-left:8px; }
-#ob_close_text,.ob_controls,#ob_load_text {
+#ob_close_text,#ob_left,#ob_right,#ob_load_text {
 	color: #fff;
 	font-size: 250%;
 	text-shadow: 1px 1px 1px #000;

--- a/orangebox/js/orangebox.js
+++ b/orangebox/js/orangebox.js
@@ -34,7 +34,8 @@ if (typeof oB !== 'undefined') {
                 slideshowTimer: 3000,
                 streamItems: 10,
                 logging: false,
-                checkAlias: true
+                checkAlias: true,
+                noImages: false
             },
             methods: {
                 init: function (o) {
@@ -42,7 +43,7 @@ if (typeof oB !== 'undefined') {
                         if (oB.ourl.match(/#\..{1,}\.facebook/)) {
                             oB.ourl = oB.ourl.substr(0, oB.ourl.search(/#\..{1,}\.facebook/));
                         }
-                        if (oB.ourl.match(/^#[A-Za-z0-9_\-]{1,}$/) && $('#' + oB.ourl).length > 0) {
+                        if (oB.ourl.match(/^#\w{1,}$/) && $('#' + oB.ourl).length > 0) {
                             oB.methods.create($('#' + oB.ourl));
                         } else {
                             $(searchTerm).each(function () {
@@ -230,10 +231,10 @@ if (typeof oB !== 'undefined') {
                         } else if (u.match(/^http:\/\/\w{0,3}\.?viddler\.com\/(?:simple|player)\/\w{1,10}$/i)) {
                             id = u.match(/viddler\.com\/(player|simple)\/\w{1,}/)[0].substring(19);
                             c = "viddler";
-                        } else if (u.match(/^#[A-Za-z0-9_\-]{1,}$/i)) {
+                        } else if (u.match(/^#\w{1,}$/i)) {
                             c = "inline";
                         } else {
-                            oB.methods.logit('Unsupported Media:s ' + u);
+                            oB.methods.logit('Unsupported Media: ' + u);
                         }
                         if (c && c !== "flickr" && c !== "picasa") {
                             $.each(oB.gallery, function() {
@@ -351,6 +352,36 @@ if (typeof oB !== 'undefined') {
                     }
                 },
                 showContent: function (obj, initial) {
+                    var navRight = $('<a class="ob_nav" id="ob_right"><span class="ob_controls" id="ob_right-ico"></span></a>').click(function (e) {
+                        if (oB.progress === null) {
+                            oB.methods.slideshowPause();
+                            e.stopPropagation();
+                            oB.methods.navigate(1);
+                        }
+                    })
+                    var navLeft = $('<a class="ob_nav" id="ob_left"><span class="ob_controls" id="ob_left-ico"></span></a>').click(function (e) {
+                        if (oB.progress === null) {
+                            oB.methods.slideshowPause();
+                            e.stopPropagation();
+                            oB.methods.navigate(-1);
+                        }
+                    })
+                    if(oB.settings.noImages) {
+                        navRight = $('<a class="ob_nav" id="ob_right"><span class="ob_controls" id="ob_right-ico ob_right-ico_text">&#8677;</span></a>').click(function (e) {
+                            if (oB.progress === null) {
+                                oB.methods.slideshowPause();
+                                e.stopPropagation();
+                                oB.methods.navigate(1);
+                            }
+                        })
+                        navLeft = $('<a class="ob_nav" id="ob_left"><span class="ob_controls" id="ob_left-ico ob_left-ico_text">&#8676;</span></a>').click(function (e) {
+                            if (oB.progress === null) {
+                                oB.methods.slideshowPause();
+                                e.stopPropagation();
+                                oB.methods.navigate(-1);
+                            }
+                        })
+                    }
                     var href = obj.data('oB').href,
                         title = obj.data('oB').title,
                         contentType = obj.data('oB').contentType,
@@ -358,20 +389,8 @@ if (typeof oB !== 'undefined') {
                         ob_caption = '',
                         ob_caption_text = '',
                         tag = href,
-                        navRight = $('<a class="ob_nav" id="ob_right"><span class="ob_controls" id="ob_right-ico"></span></a>').click(function (e) {
-                            if (oB.progress === null) {
-                                oB.methods.slideshowPause();
-                                e.stopPropagation();
-                                oB.methods.navigate(1);
-                            }
-                        }),
-                        navLeft = $('<a class="ob_nav" id="ob_left"><span class="ob_controls" id="ob_left-ico"></span></a>').click(function (e) {
-                            if (oB.progress === null) {
-                                oB.methods.slideshowPause();
-                                e.stopPropagation();
-                                oB.methods.navigate(-1);
-                            }
-                        }),
+                        navRight,
+                        navLeft,
                         dotnav = $('<ul id="ob_dots"></ul>').click(function (e) { e.stopPropagation(); }),
                         ob_link;
                     if(obj.data('oB').caption) {
@@ -414,10 +433,17 @@ if (typeof oB !== 'undefined') {
                         }
                     }
                     if (oB.settings.showClose) {
-                        $('#ob_content').append($('<div title="close" class="ob_controls ob_cs" id="ob_close"></div>').click(function (e) {
-                            e.stopPropagation();
-                            oB.methods.destroy();
-                        }));
+                        if(oB.settings.noImages) {
+                            $('#ob_content').append($('<div title="close" class="ob_controls ob_cs" id="ob_close_text">&#x02297;</div>').click(function (e) {
+                                e.stopPropagation();
+                                oB.methods.destroy();
+                            }));
+                        } else {
+                            $('#ob_content').append($('<div title="close" class="ob_controls ob_cs" id="ob_close"></div>').click(function (e) {
+                                e.stopPropagation();
+                                oB.methods.destroy();
+                            }));
+                        }
                     }
 
                     //Update Navigation
@@ -873,7 +899,11 @@ if (typeof oB !== 'undefined') {
                     }
                 },
                 showLoad: function (x) {
-                    var ob_load = $('<div id="ob_load"></div>').hide();
+                    if(oB.settings.noImages) {
+                        var ob_load = $('<div id="ob_load ob_load_text">&#9684;</div>').hide();
+                    } else {
+                        var ob_load = $('<div id="ob_load"></div>').hide();
+                    }
                     if ($('#ob_load').length > 0 || x) {
                         clearTimeout(oB.loadTimer);
                         $('#ob_load').remove();


### PR DESCRIPTION
Hi there, I've written Panfolio to create photo galleries and thought about using OrangeBox for the lightbox effect, and as a pretty neat side effect have the sharing features in a per photo basis some users wanted, but it uses images for the loading effect and lightbox controls, as most of plug-ins out there.

This patch is not the prettiest I know, but I've never written any javascript before so... it does work fine to me. There's a live demo of my gallery app using OrangeBox at http://caio.ueberalles.net/panfolio-demo/

The choice for those unicode symbols was very particular, perhaps they could also be customizable through some options, I don't know. Anyway, I'd simply love to use your vanilla plug-in if you can merge this patch, otherwise I'll keep this mod to me!

Cheers :-)
